### PR TITLE
Add nltk dataset needed to install before run

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ which you can install issuing the following command:
 
     pip install -r requirements.txt
 
-You also need to install NLTK's Treebank PoS-tagger and stop words list:
+You also need to install NLTK's Treebank PoS-tagger, stop words list, punkt, and wordnet:
 
     import nltk
     nltk.download('maxent_treebank_pos_tagger')
     nltk.download('stopwords')
+    nltk.download('punkt')
+    nltk.download('wordnet')
 
 Usage:
 =====


### PR DESCRIPTION
I've generated following error before run sample script (nltk==3.4.5)

```
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt')
```

```
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')
```

So I added some dataset installation precedure on README.md