### PR TITLE
Fix test failure on Windows due to NamedTemporaryFile behavior

### DIFF
--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -1,5 +1,5 @@
 import tempfile
-
+import os
 import pytest
 
 from breds.commons import blocks
@@ -8,11 +8,13 @@ from breds.commons import blocks
 @pytest.fixture
 def tmp_file():
     """Create a temporary file with 100 lines, each containing a single byte"""
-    with tempfile.NamedTemporaryFile(mode="wt") as f:
+    with tempfile.NamedTemporaryFile(mode="wt", delete=False) as f:
         for _ in range(100):
             f.write("\n")
         f.flush()
-        yield f.name
+        tmp_path = f.name  # store path before file is closed
+    yield tmp_path
+    os.remove(tmp_path)  # clean up after the test
 
 
 def test_blocks(tmp_file):


### PR DESCRIPTION
Hello. While running the tests on Windows, I encountered a `PermissionError` caused by how `tempfile.NamedTemporaryFile` behaves on this platform. On Windows, temporary files created with NamedTemporaryFile cannot be reopened while still open, unlike on Unix-based systems.

To make the test portable across platforms, I modified the fixture to:

- Use delete=False so the file can be reopened.
- Close the file before using it in the test.
- Explicitly delete the file after the test finishes.

This ensure the test works consistently on both Windows and Linux/macOS.